### PR TITLE
Add install script and access controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.env
+venv/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-# renew-bot
+# Renew Bot
+
+Telegram bot for Marzban renewals.
+
+## Installation
+
+1. Ensure Python 3.10+ is installed.
+2. Run the install script and follow the prompts:
+   ```bash
+   bash install.sh
+   ```
+   The script will ask for:
+   - **Bot token**
+   - **Super admin Telegram ID** (comma separated for multiple)
+   - **Panel address**
+   - **Sudo username**
+   - **Sudo password**
+   - **Bot status** (`on` or `off`)
+
+   The script creates a `.env` file, sets up a virtual environment and installs dependencies.
+3. Start the bot:
+   ```bash
+   source venv/bin/activate
+   python bot.py
+   ```
+
+Only Telegram IDs configured as admins can interact with the bot; everyone else is ignored. The super admin is the only role allowed to add balance to other admins.
+
+## Environment variables
+
+| Variable | Description |
+|----------|-------------|
+| `TELEGRAM_TOKEN` | Telegram bot token |
+| `SUPERADMIN_IDS` | Comma-separated super admin Telegram IDs |
+| `MARZBAN_ADDRESS` | Marzban panel URL |
+| `MARZBAN_USERNAME` | Marzban sudo username |
+| `MARZBAN_PASSWORD` | Marzban sudo password |
+| `BOT_STATUS` | `on` to run the bot, `off` to exit immediately |

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+read -p "Bot token: " TELEGRAM_TOKEN
+read -p "Superadmin ID(s) (comma separated): " SUPERADMIN_IDS
+read -p "Panel address: " MARZBAN_ADDRESS
+read -p "Sudo username: " MARZBAN_USERNAME
+read -s -p "Sudo password: " MARZBAN_PASSWORD
+echo
+read -p "Bot status (on/off) [on]: " BOT_STATUS
+BOT_STATUS=${BOT_STATUS:-on}
+
+cat > .env <<EOT
+TELEGRAM_TOKEN=$TELEGRAM_TOKEN
+SUPERADMIN_IDS=$SUPERADMIN_IDS
+MARZBAN_ADDRESS=$MARZBAN_ADDRESS
+MARZBAN_USERNAME=$MARZBAN_USERNAME
+MARZBAN_PASSWORD=$MARZBAN_PASSWORD
+BOT_STATUS=$BOT_STATUS
+EOT
+
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+
+echo "\nInstallation complete. Activate with 'source venv/bin/activate' and run 'python bot.py'."

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+aiohttp
+aiogram==2.25.2
+jdatetime
+pytz


### PR DESCRIPTION
## Summary
- document setup and environment variables in README
- add interactive install.sh for bot configuration
- allow toggling bot via BOT_STATUS and ignore unauthorized users

## Testing
- `bash -n install.sh`
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_b_689dc37b7fa88329a9eebdb54f5fc35e