### PR TITLE
Add renew service module and installer options

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,19 @@
 
 Telegram bot for Marzban renewals.
 
+## Prerequisites
+
+- Python 3.10 or newer
+- `python3-venv` to create virtual environments (e.g. `sudo apt install python3-venv`)
+- `git` (if cloning the repository)
+
 ## Installation
 
-1. Ensure Python 3.10+ is installed.
-2. Run the install script and follow the prompts:
+1. Run the install script:
    ```bash
    bash install.sh
    ```
-   The script will ask for:
+   On first run it will ask for:
    - **Bot token**
    - **Super admin Telegram ID** (comma separated for multiple)
    - **Panel address**
@@ -17,8 +22,16 @@ Telegram bot for Marzban renewals.
    - **Sudo password**
    - **Bot status** (`on` or `off`)
 
-   The script creates a `.env` file, sets up a virtual environment and installs dependencies.
-3. Start the bot:
+   A `.env` file is created, a virtual environment is set up and dependencies are installed.
+   Subsequent runs reuse the existing `.env`.  To change values run:
+   ```bash
+   bash install.sh --configure
+   ```
+   To remove the virtual environment, configuration and database, run:
+   ```bash
+   bash install.sh uninstall
+   ```
+2. Start the bot:
    ```bash
    source venv/bin/activate
    python bot.py

--- a/install.sh
+++ b/install.sh
@@ -1,16 +1,43 @@
 #!/bin/bash
 set -e
 
-read -p "Bot token: " TELEGRAM_TOKEN
-read -p "Superadmin ID(s) (comma separated): " SUPERADMIN_IDS
-read -p "Panel address: " MARZBAN_ADDRESS
-read -p "Sudo username: " MARZBAN_USERNAME
-read -s -p "Sudo password: " MARZBAN_PASSWORD
-echo
-read -p "Bot status (on/off) [on]: " BOT_STATUS
-BOT_STATUS=${BOT_STATUS:-on}
+ENV_FILE=".env"
+DB_DIR="/var/lib/marzban/renew-tg-bot"
 
-cat > .env <<EOT
+if [ "$1" = "uninstall" ]; then
+  rm -rf venv "$ENV_FILE" "$DB_DIR"
+  echo "Uninstallation complete."
+  exit 0
+fi
+
+CONFIGURE=false
+if [ "$1" = "--configure" ] || [ ! -f "$ENV_FILE" ]; then
+  CONFIGURE=true
+fi
+
+if [ "$CONFIGURE" = true ]; then
+  [ -f "$ENV_FILE" ] && source "$ENV_FILE"
+
+  read -p "Bot token [${TELEGRAM_TOKEN:-}]: " input
+  TELEGRAM_TOKEN=${input:-$TELEGRAM_TOKEN}
+
+  read -p "Superadmin ID(s) (comma separated) [${SUPERADMIN_IDS:-}]: " input
+  SUPERADMIN_IDS=${input:-$SUPERADMIN_IDS}
+
+  read -p "Panel address [${MARZBAN_ADDRESS:-}]: " input
+  MARZBAN_ADDRESS=${input:-$MARZBAN_ADDRESS}
+
+  read -p "Sudo username [${MARZBAN_USERNAME:-}]: " input
+  MARZBAN_USERNAME=${input:-$MARZBAN_USERNAME}
+
+  read -s -p "Sudo password [${MARZBAN_PASSWORD:+***}]: " input
+  echo
+  MARZBAN_PASSWORD=${input:-$MARZBAN_PASSWORD}
+
+  read -p "Bot status (on/off) [${BOT_STATUS:-on}]: " input
+  BOT_STATUS=${input:-${BOT_STATUS:-on}}
+
+  cat > "$ENV_FILE" <<EOT
 TELEGRAM_TOKEN=$TELEGRAM_TOKEN
 SUPERADMIN_IDS=$SUPERADMIN_IDS
 MARZBAN_ADDRESS=$MARZBAN_ADDRESS
@@ -18,8 +45,14 @@ MARZBAN_USERNAME=$MARZBAN_USERNAME
 MARZBAN_PASSWORD=$MARZBAN_PASSWORD
 BOT_STATUS=$BOT_STATUS
 EOT
+else
+  echo "Using existing configuration from $ENV_FILE. Run '$0 --configure' to modify."
+  source "$ENV_FILE"
+fi
 
-python3 -m venv venv
+if [ ! -d venv ]; then
+  python3 -m venv venv
+fi
 source venv/bin/activate
 pip install -r requirements.txt
 

--- a/renew_service.py
+++ b/renew_service.py
@@ -1,0 +1,42 @@
+import aiohttp
+
+
+class MarzbanRenewService:
+    """Simple client for renewing Marzban users.
+
+    Parameters are pulled from environment variables in ``bot.py`` and
+    provided here.  The service keeps an ``aiohttp`` session with basic
+    authentication and exposes a helper for renewing a user for 31 days.
+    """
+
+    def __init__(self, address: str, username: str, password: str):
+        self._base = address.rstrip("/")
+        self._auth = aiohttp.BasicAuth(username, password)
+        self._session = aiohttp.ClientSession(auth=self._auth)
+
+    async def renew_user_31d(self, username: str) -> dict:
+        """Renew *username* for 31 days.
+
+        Returns a dictionary with ``ok`` and ``message`` keys describing the
+        outcome so that ``bot.py`` can act on the response.  Any unexpected
+        error is caught and converted into ``ok=False`` with the error message.
+        """
+        url = f"{self._base}/api/users/{username}/renew"
+        payload = {"duration": 31}
+        try:
+            async with self._session.post(url, json=payload) as resp:
+                if resp.status == 200:
+                    try:
+                        data = await resp.json()
+                        msg = data.get("message", "") if isinstance(data, dict) else ""
+                    except aiohttp.ContentTypeError:
+                        msg = await resp.text()
+                    return {"ok": True, "message": msg}
+                text = await resp.text()
+                return {"ok": False, "message": text}
+        except Exception as exc:  # pragma: no cover - network errors
+            return {"ok": False, "message": str(exc)}
+
+    async def close(self) -> None:
+        """Close the underlying ``aiohttp`` session."""
+        await self._session.close()


### PR DESCRIPTION
## Summary
- implement `MarzbanRenewService` module
- make installer reuse existing config, allow reconfigure or uninstall
- document prerequisites and new installer options in README

## Testing
- `python -m py_compile bot.py renew_service.py`
- `pip install -r requirements.txt` *(fails: Building wheel for aiohttp did not run successfully)*
- `pip install aiohttp==3.9.5`
- `pip install jdatetime pytz`
- `pip install aiogram==2.25.2 --no-deps`
- `pip install babel`
- `pip install certifi magic-filter`
- `TELEGRAM_TOKEN=123456:ABCDEF BOT_STATUS=off python bot.py`

------
https://chatgpt.com/codex/tasks/task_b_689dca540a6c832988fd946c872f25de