### PR TITLE
Prevent blank config values and add superadmin customer list

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -167,6 +167,7 @@ def admin_kb(is_super: bool) -> ReplyKeyboardMarkup:
         kb.row(KeyboardButton("➕ شارژ اعتبار"), KeyboardButton("🔁 تمدید برای مشتری"))
         kb.row(KeyboardButton("🔎 اعتبار مشتری"), KeyboardButton("👑 مدیریت ادمین‌ها"))
         kb.add(KeyboardButton("👥 لیست ادمین‌ها"))
+        kb.add(KeyboardButton("👥 لیست مشتری‌ها"))
     else:
         # ادمین معمولی فقط عملیات‌های مرتبط با تمدید را می‌بیند
         kb.row(KeyboardButton("🔁 تمدید برای مشتری"), KeyboardButton("🔎 اعتبار مشتری"))
@@ -575,6 +576,21 @@ async def admins_list(m: types.Message):
         name = f" - {fname}" if fname else ""
         lines.append(f"• {tid}  {tag}{name}")
     await m.reply("لیست ادمین‌ها:\n" + "\n".join(lines))
+
+# ---- لیست مشتری‌ها (فقط سوپرادمین)
+@dp.message_handler(lambda msg: msg.text == "👥 لیست مشتری‌ها")
+async def customers_list(m: types.Message):
+    sync_admin_profile_if_needed(m.from_user)
+    if not is_superadmin(m.from_user.id):
+        return await m.reply("فقط سوپرادمین.")
+    with closing(sqlite3.connect(DB_PATH)) as conn:
+        rows = conn.execute(
+            "SELECT telegram_id, credits FROM customers ORDER BY telegram_id"
+        ).fetchall()
+    if not rows:
+        return await m.reply("هیچ مشتری‌ای در سیستم ثبت نشده است.")
+    lines = [f"• {tid} - اعتبار: {credits}" for tid, credits in rows]
+    await m.reply("لیست مشتری‌ها:\n" + "\n".join(lines))
 
 # ---------------- اجرا ----------------
 if __name__ == "__main__":

--- a/install.sh
+++ b/install.sh
@@ -18,24 +18,52 @@ fi
 if [ "$CONFIGURE" = true ]; then
   [ -f "$ENV_FILE" ] && source "$ENV_FILE"
 
-  read -p "Bot token [${TELEGRAM_TOKEN:-}]: " input
-  TELEGRAM_TOKEN=${input:-$TELEGRAM_TOKEN}
+  while true; do
+    read -p "Bot token [${TELEGRAM_TOKEN:-}]: " input
+    TELEGRAM_TOKEN=${input:-$TELEGRAM_TOKEN}
+    [ -n "$TELEGRAM_TOKEN" ] && break
+    echo "Bot token cannot be blank."
+  done
 
-  read -p "Superadmin ID(s) (comma separated) [${SUPERADMIN_IDS:-}]: " input
-  SUPERADMIN_IDS=${input:-$SUPERADMIN_IDS}
+  while true; do
+    read -p "Superadmin ID(s) (comma separated) [${SUPERADMIN_IDS:-}]: " input
+    SUPERADMIN_IDS=${input:-$SUPERADMIN_IDS}
+    [ -n "$SUPERADMIN_IDS" ] && break
+    echo "Superadmin ID(s) cannot be blank."
+  done
 
-  read -p "Panel address [${MARZBAN_ADDRESS:-}]: " input
-  MARZBAN_ADDRESS=${input:-$MARZBAN_ADDRESS}
+  while true; do
+    read -p "Panel address [${MARZBAN_ADDRESS:-}]: " input
+    MARZBAN_ADDRESS=${input:-$MARZBAN_ADDRESS}
+    [ -n "$MARZBAN_ADDRESS" ] && break
+    echo "Panel address cannot be blank."
+  done
 
-  read -p "Sudo username [${MARZBAN_USERNAME:-}]: " input
-  MARZBAN_USERNAME=${input:-$MARZBAN_USERNAME}
+  while true; do
+    read -p "Sudo username [${MARZBAN_USERNAME:-}]: " input
+    MARZBAN_USERNAME=${input:-$MARZBAN_USERNAME}
+    [ -n "$MARZBAN_USERNAME" ] && break
+    echo "Sudo username cannot be blank."
+  done
 
-  read -s -p "Sudo password [${MARZBAN_PASSWORD:+***}]: " input
-  echo
-  MARZBAN_PASSWORD=${input:-$MARZBAN_PASSWORD}
+  while true; do
+    read -s -p "Sudo password [${MARZBAN_PASSWORD:+***}]: " input
+    echo
+    MARZBAN_PASSWORD=${input:-$MARZBAN_PASSWORD}
+    [ -n "$MARZBAN_PASSWORD" ] && break
+    echo "Sudo password cannot be blank."
+  done
 
-  read -p "Bot status (on/off) [${BOT_STATUS:-on}]: " input
-  BOT_STATUS=${input:-${BOT_STATUS:-on}}
+  while true; do
+    read -p "Bot status (on/off) [${BOT_STATUS:-on}]: " input
+    BOT_STATUS=${input:-${BOT_STATUS:-on}}
+    BOT_STATUS=${BOT_STATUS,,}
+    [ -z "$BOT_STATUS" ] && BOT_STATUS="on"
+    if [[ "$BOT_STATUS" == "on" || "$BOT_STATUS" == "off" ]]; then
+      break
+    fi
+    echo "Enter 'on' or 'off'."
+  done
 
   cat > "$ENV_FILE" <<EOT
 TELEGRAM_TOKEN=$TELEGRAM_TOKEN

--- a/renew_service.py
+++ b/renew_service.py
@@ -1,4 +1,5 @@
 import aiohttp
+from urllib.parse import quote
 
 
 class MarzbanRenewService:
@@ -21,7 +22,11 @@ class MarzbanRenewService:
         outcome so that ``bot.py`` can act on the response.  Any unexpected
         error is caught and converted into ``ok=False`` with the error message.
         """
-        url = f"{self._base}/api/users/{username}/renew"
+        # The Marzban API uses the singular form ``user`` in the renewal endpoint.
+        # Using ``users`` causes a 404 with ``{"detail": "Not Found"}`` even when
+        # the username exists.
+        username_enc = quote(username, safe="")
+        url = f"{self._base}/api/user/{username_enc}/renew"
         payload = {"duration": 31}
         try:
             async with self._session.post(url, json=payload) as resp:


### PR DESCRIPTION
## Summary
- Disallow blank installer inputs except bot status, defaulting status to on
- Add "list customers" option for superadmins and fix renewal API path

## Testing
- `bash -n install.sh`
- `python -m py_compile bot.py renew_service.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689dd5d218988329a2f340e41fa754ad