### PR TITLE
feat: add token-based user renewal service

### DIFF
--- a/renew_service.py
+++ b/renew_service.py
@@ -1,47 +1,140 @@
+import asyncio
+from datetime import datetime, timedelta, timezone
+from typing import Optional, Dict, Any
+
 import aiohttp
-from urllib.parse import quote
 
 
 class MarzbanRenewService:
-    """Simple client for renewing Marzban users.
-
-    Parameters are pulled from environment variables in ``bot.py`` and
-    provided here.  The service keeps an ``aiohttp`` session with basic
-    authentication and exposes a helper for renewing a user for 31 days.
+    """
+    تمدید دقیقاً ۳۱ روز از «الان»، ریست حجم، و Active کردن کاربر.
+    اگر کاربر وجود نداشت، پیام فارسی برمی‌گرداند.
     """
 
     def __init__(self, address: str, username: str, password: str):
-        self._base = address.rstrip("/")
-        self._auth = aiohttp.BasicAuth(username, password)
-        self._session = aiohttp.ClientSession(auth=self._auth)
+        self.address = address.rstrip("/")
+        self.username = username
+        self.password = password
+        self.session: Optional[aiohttp.ClientSession] = None
+        self._token: Optional[str] = None
 
-    async def renew_user_31d(self, username: str) -> dict:
-        """Renew *username* for 31 days.
+    async def _ensure_session(self):
+        if self.session is None or self.session.closed:
+            timeout = aiohttp.ClientTimeout(total=40)
+            # اگر SSL خودامضا دارید و خطای SSL دیدید، ssl=False را باز کنید (غیرتوصیه‌شده):
+            # connector = aiohttp.TCPConnector(ssl=False)
+            # self.session = aiohttp.ClientSession(timeout=timeout, connector=connector)
+            self.session = aiohttp.ClientSession(timeout=timeout)
 
-        Returns a dictionary with ``ok`` and ``message`` keys describing the
-        outcome so that ``bot.py`` can act on the response.  Any unexpected
-        error is caught and converted into ``ok=False`` with the error message.
+    async def close(self):
+        if self.session and not self.session.closed:
+            await self.session.close()
+
+    async def _auth_headers(self) -> Dict[str, str]:
+        await self._ensure_session()
+        if not self._token:
+            # گرفتن توکن ادمین با application/x-www-form-urlencoded
+            url = f"{self.address}/api/admin/token"
+            form = {"username": self.username, "password": self.password}
+            headers = {"Content-Type": "application/x-www-form-urlencoded"}
+            async with self.session.post(url, data=form, headers=headers) as r:
+                text = await r.text()
+                if r.status != 200:
+                    raise RuntimeError(f"عدم موفقیت در دریافت توکن ({r.status}): {text}")
+                try:
+                    data = await r.json()
+                except Exception:
+                    raise RuntimeError(f"پاسخ غیرقابل‌خواندن از سرور توکن: {text}")
+                self._token = data.get("access_token") or data.get("token")
+                if not self._token:
+                    raise RuntimeError(f"توکن در پاسخ سرور یافت نشد: {data}")
+        return {"Authorization": f"Bearer {self._token}"}
+
+    @staticmethod
+    def _expire_in_31_days_seconds() -> int:
+        # مارزبان timestamp را به «ثانیه» می‌پذیرد
+        expires_at = datetime.now(timezone.utc) + timedelta(days=31)
+        return int(expires_at.timestamp())
+
+    async def _get_user(self, username: str) -> Optional[Dict[str, Any]]:
+        headers = await self._auth_headers()
+        url = f"{self.address}/api/user/{username}"
+        async with self.session.get(url, headers=headers) as r:
+            if r.status == 404:
+                return None
+            if r.status != 200:
+                text = await r.text()
+                raise RuntimeError(f"خطا در دریافت کاربر ({r.status}): {text}")
+            return await r.json()
+
+    async def _modify_user(self, username: str, **fields) -> Dict[str, Any]:
+        headers = await self._auth_headers()
+        url = f"{self.address}/api/user/{username}"
+        async with self.session.put(url, headers=headers, json=fields) as r:
+            text = await r.text()
+            if r.status not in (200, 201):
+                raise RuntimeError(f"خطا در بروزرسانی کاربر ({r.status}): {text}")
+            try:
+                return await r.json()
+            except Exception:
+                return {"raw": text}
+
+    async def _reset_usage(self, username: str) -> None:
+        headers = await self._auth_headers()
+        url = f"{self.address}/api/user/{username}/reset"
+        async with self.session.post(url, headers=headers) as r:
+            if r.status not in (200, 204):
+                text = await r.text()
+                raise RuntimeError(f"خطا در ریست مصرف ({r.status}): {text}")
+
+    async def renew_user_31d(self, username: str) -> Dict[str, Any]:
         """
-        # The Marzban API uses the singular form ``user`` in the renewal endpoint.
-        # Using ``users`` causes a 404 with ``{"detail": "Not Found"}`` even when
-        # the username exists.
-        username_enc = quote(username, safe="")
-        url = f"{self._base}/api/user/{username_enc}/renew"
-        payload = {"duration": 31}
-        try:
-            async with self._session.post(url, json=payload) as resp:
-                if resp.status == 200:
-                    try:
-                        data = await resp.json()
-                        msg = data.get("message", "") if isinstance(data, dict) else ""
-                    except aiohttp.ContentTypeError:
-                        msg = await resp.text()
-                    return {"ok": True, "message": msg}
-                text = await resp.text()
-                return {"ok": False, "message": text}
-        except Exception as exc:  # pragma: no cover - network errors
-            return {"ok": False, "message": str(exc)}
+        - اگر نبود: پیام فارسی «این کاربر وجود ندارد.»
+        - اگر بود: expire = now + 31d (ثانیه)، status=active، reset usage
+        """
+        user = await self._get_user(username)
+        if user is None:
+            return {"ok": False, "message": "این کاربر وجود ندارد."}
 
-    async def close(self) -> None:
-        """Close the underlying ``aiohttp`` session."""
-        await self._session.close()
+        new_expire = self._expire_in_31_days_seconds()
+
+        # 1) تنظیم expire دقیقاً برای ۳۱ روز آینده + Active
+        await self._modify_user(username, expire=new_expire, status="active")
+
+        # 2) ریست حجم مصرفی
+        await self._reset_usage(username)
+
+        # 3) وضعیت نهایی
+        latest = await self._get_user(username)
+        return {
+            "ok": True,
+            "message": "تمدید با موفقیت انجام شد: ۳۱ روزه + ریست حجم + اکتیوسازی.",
+            "user": (latest or {}).get("username", username),
+            "expire": new_expire,
+        }
+
+
+# ---- CLI برای استفاده مستقیم ----
+if __name__ == "__main__":
+    import argparse
+    import os
+    from dotenv import load_dotenv
+
+    load_dotenv()
+
+    parser = argparse.ArgumentParser(description="Marzban: renew user for exactly 31 days, reset traffic and activate.")
+    parser.add_argument("--address", required=False, default=os.getenv("MARZBAN_ADDRESS", "https://yourpanel.com/"))
+    parser.add_argument("--admin", required=False, default=os.getenv("MARZBAN_USERNAME", "sudo_username"))
+    parser.add_argument("--password", required=False, default=os.getenv("MARZBAN_PASSWORD", "sudo_password"))
+    parser.add_argument("username", help="Marzban username to renew")
+    args = parser.parse_args()
+
+    async def _run():
+        svc = MarzbanRenewService(args.address, args.admin, args.password)
+        try:
+            res = await svc.renew_user_31d(args.username)
+            print(res.get("message"))
+        finally:
+            await svc.close()
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- replace renewal logic with token-based API client
- reset user traffic and activate account during renewal
- allow CLI to read Marzban credentials from environment

## Testing
- `python -m py_compile bot.py renew_service.py`


------
https://chatgpt.com/codex/tasks/task_b_689dd88d237083299e7e631b6c2a8724