### PR TITLE
Ignore unknown users

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Telegram bot for Marzban renewals.
    python bot.py
    ```
 
-Only Telegram IDs configured as admins can interact with the bot; everyone else is ignored. The super admin is the only role allowed to add balance to other admins.
+Only Telegram IDs configured as admins or those already registered as customers can interact with the bot. Others are ignored and not stored. The super admin is the only role allowed to add balance to other admins.
 
 ## Environment variables
 


### PR DESCRIPTION
## Summary
- Avoid adding unknown users to the customers list and ignore their messages
- Only existing customers or admins can interact with the bot; others get no response
- Document that unregistered users are ignored

## Testing
- `python -m py_compile bot.py renew_service.py`


------
https://chatgpt.com/codex/tasks/task_b_689de55d57c483298b0a5ba4b18a61d4