### PR TITLE
docs: update README with python3 and download instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,40 +2,64 @@
 
 Telegram bot for Marzban renewals.
 
+## Get the code
+
+Clone with git:
+
+```bash
+git clone https://github.com/your-username/renew-bot.git
+cd renew-bot
+```
+
+Or download with curl:
+
+```bash
+curl -L -o renew-bot.tar.gz https://github.com/your-username/renew-bot/archive/refs/heads/main.tar.gz
+tar -xzf renew-bot.tar.gz
+cd renew-bot-main
+```
+
 ## Prerequisites
 
 - Python 3.10 or newer
 - `python3-venv` to create virtual environments (e.g. `sudo apt install python3-venv`)
 - `git` (if cloning the repository)
+- `curl` (if downloading via curl)
 
 ## Installation
 
 1. Run the install script:
-   ```bash
-   bash install.sh
-   ```
-   On first run it will ask for:
-   - **Bot token**
-   - **Super admin Telegram ID** (comma separated for multiple)
-   - **Panel address**
-   - **Sudo username**
-   - **Sudo password**
-   - **Bot status** (`on` or `off`)
 
-   A `.env` file is created, a virtual environment is set up and dependencies are installed.
-   Subsequent runs reuse the existing `.env`.  To change values run:
-   ```bash
-   bash install.sh --configure
-   ```
-   To remove the virtual environment, configuration and database, run:
-   ```bash
-   bash install.sh uninstall
-   ```
+```bash
+bash install.sh
+```
+
+On first run it will ask for:
+- **Bot token**
+- **Super admin Telegram ID** (comma separated for multiple)
+- **Panel address**
+- **Sudo username**
+- **Sudo password**
+- **Bot status** (`on` or `off`)
+
+A `.env` file is created, a virtual environment is set up and dependencies are installed. Subsequent runs reuse the existing `.env`. To change values run:
+
+```bash
+bash install.sh --configure
+```
+
+To remove the virtual environment, configuration and database, run:
+
+```bash
+bash install.sh uninstall
+```
+
 2. Start the bot:
-   ```bash
-   source venv/bin/activate
-   python bot.py
-   ```
+
+```bash
+source venv/bin/activate
+python3 bot.py
+```
 
 Only Telegram IDs configured as admins or those already registered as customers can interact with the bot. Others are ignored and not stored. The super admin is the only role allowed to add balance to other admins.
 


### PR DESCRIPTION
## Summary
- document cloning via git and curl
- clarify prerequisites and python3 usage

## Testing
- `python3 -m py_compile bot.py renew_service.py`


------
https://chatgpt.com/codex/tasks/task_b_689deda1528c83298e8f2a9b7aadcc57