### PR TITLE
Add systemd service unit and management instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,28 @@ Only Telegram IDs configured as admins or those already registered as customers 
 | `MARZBAN_USERNAME` | Marzban sudo username |
 | `MARZBAN_PASSWORD` | Marzban sudo password |
 | `BOT_STATUS` | `on` to run the bot, `off` to exit immediately |
+
+## Run with systemd
+
+A sample unit file `renew-bot.service` is provided to run the bot as a
+service. Adjust the `User`, `WorkingDirectory` and `ExecStart` paths as
+needed, then install and enable it:
+
+```bash
+sudo cp renew-bot.service /etc/systemd/system/renew-bot.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now renew-bot
+```
+
+Useful commands to manage the service:
+
+```bash
+sudo systemctl status renew-bot   # view status
+sudo systemctl stop renew-bot     # stop the bot
+sudo systemctl start renew-bot    # start the bot
+sudo systemctl restart renew-bot  # restart the bot
+```
+
+`Restart=always` in the unit file ensures the bot is restarted if it
+exits unexpectedly, and enabling the service makes it start automatically
+after reboots.

--- a/renew-bot.service
+++ b/renew-bot.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Renew Bot Telegram bot
+After=network.target
+
+[Service]
+Type=simple
+# User that will run the bot. Adjust if you do not want to run as root.
+User=root
+# Working directory where bot.py and the .env file reside
+WorkingDirectory=/opt/renew-bot
+# Run the bot using the virtual environment's python
+ExecStart=/opt/renew-bot/venv/bin/python bot.py
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add a sample `systemd` service file to run the bot persistently
- document service installation and management commands in README

## Testing
- `python -m py_compile bot.py renew_service.py`


------
https://chatgpt.com/codex/tasks/task_b_689df174e56c83299ecab69fd84176aa